### PR TITLE
fix: FURTHER TESTING REQUIRED! Attempt to fix issue (#32)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>codes.wasabi</groupId>
     <artifactId>xclaim</artifactId>
-    <version>1.9.6</version>
+    <version>1.9.6-fix#32</version>
     <packaging>jar</packaging>
 
     <name>XClaim</name>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.1.1</version>
+            <version>4.1.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/codes/wasabi/xclaim/XClaim.java
+++ b/src/main/java/codes/wasabi/xclaim/XClaim.java
@@ -254,8 +254,10 @@ public final class XClaim extends JavaPlugin {
     private void saveClaims() {
         logger.log(Level.INFO, lang.get("claims-save"));
         Set<String> removeKeys = claimsConfig.getKeys(false);
+        int index = 0;
         for (Claim claim : Claim.getAll()) {
-            String name = claim.getName();
+            String name = index + ": " + claim.getOwner().getUniqueId() + "-" + claim.getName();
+            index ++;
             ConfigurationSection section = claimsConfig.getConfigurationSection(name);
             if (section == null) section = claimsConfig.createSection(name);
             //

--- a/src/main/java/codes/wasabi/xclaim/api/Claim.java
+++ b/src/main/java/codes/wasabi/xclaim/api/Claim.java
@@ -478,7 +478,7 @@ public class Claim {
         // prevent ConcurrentModificationException
         for (Claim c : new HashSet<>(registry)) {
             if (c == this) continue;
-            if (c.name.equals(name)) {
+            if (c.name.equals(name) && c.owner == owner) {
                 c.unclaim();
                 continue;
             }


### PR DESCRIPTION
Changed how primary keys in config.yml are generated. Added index and the owner's UUID to make every key unique. And added check for the owner in Claim.claim() in order to not unclaim anything, with the same name.

This solution should be easily applicable. Even to servers, that already have an old `claims.yml`, as this file is rewritten from the registry on every disabling.
As for further testing, I only checked functionality for paper-1.19.2-232, so it's still necessary to check every other compatible Minecraft version.