### PR TITLE
Do not bundle Folia api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
             <groupId>dev.folia</groupId>
             <artifactId>folia-api</artifactId>
             <version>1.19.4-R0.1-20230527.192927-40</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.papermc</groupId>


### PR DESCRIPTION
This makes it so that the Folia api won't be included in XClaim's jar file. This is unnecessary because these classes are already provided at runtime by the server implementation. This should dramatically decrease XClaim's file size, as well as fix [this issue](https://github.com/Jannyboy11/InvSee-plus-plus/issues/75).